### PR TITLE
Support latest pyyaml (>=5.1) version

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,11 @@
 Release History
 ---------------
 
-0.1.2 (unreleased)
+0.2.0 (2019-06-21)
 ++++++++++++++++++
 
-- Nothing changed yet.
+- Support PyYAML > 5 and use UnsafeLoader to evaluate environment
+variables in nameko configuration files.
 
 
 0.1.1 (2017-09-01)

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,4 @@
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.12 2.7.10 3.3.6 3.4.4 3.5.2 3.6.1
+    - pyenv local 3.3.6 3.4.4 3.5.2 3.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 nameko
 six
+pyyaml>=5.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='nameko-extras',
-    version='0.1.2.dev1',
+    version='0.2.0',
     packages=find_packages('src', exclude=('tests',)),
     package_dir={'': 'src'},
     include_package_data=True,
@@ -39,12 +39,6 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP'
     ]

--- a/src/nameko_extras/cli/run.py
+++ b/src/nameko_extras/cli/run.py
@@ -20,7 +20,7 @@ def main(args):
 
     if args.config:
         with open(args.config) as fle:
-            config = yaml.load(fle)
+            config = yaml.load(fle, Loader=yaml.UnsafeLoader)
     else:
         config = {
             AMQP_URI_CONFIG_KEY: args.broker

--- a/src/tests/test_autoreload.py
+++ b/src/tests/test_autoreload.py
@@ -10,7 +10,9 @@ from nameko_extras import autoreload
 from mock import patch, Mock
 
 
-config = {AMQP_URI_CONFIG_KEY: 'pyamqp://guest:guest@localhost'}
+config = {
+    AMQP_URI_CONFIG_KEY: 'pyamqp://guest:${RABBITMQ_PASSWORD:guest}@localhost'
+}
 
 
 @patch('nameko_extras.autoreload._reloader')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,lint
+envlist = py36,lint
 
 [testenv]
 


### PR DESCRIPTION
Problem
-------
New version deprecates `yaml.load` and doesn't use `UnsafeLoader` by default
that evaluates evars placeholders in the YAML.

Solution
--------
Switch to the latest version of PyYaml (>=5.1)

Testing
-------
All the tests pass.